### PR TITLE
Add 'types' property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "strongly-typed-events",
   "version": "0.4.1",
   "description": "Add the power of events to your (TypeScript) projects!",
-  "main": "strongly-typed-events.js",
+  "main": "./strongly-typed-events.js",
+  "types": "./strongly-typed-events.d.ts",
   "directories": {
     "example": "examples",
     "test": "tests",


### PR DESCRIPTION
First thanks for this project!

This adds the 'types' property to the package.json as recommended on https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html so that they types can be found automatically.

Closes https://github.com/KeesCBakker/Strongly-Typed-Events-for-TypeScript/issues/3